### PR TITLE
feat: 전역 예외 핸들러 세팅 및 공통 응답 객체 생성과 Warehouse 엔티티 CRUD 로직 구현

### DIFF
--- a/src/main/java/io/inventory/common/exception/CommonExceptionHandler.java
+++ b/src/main/java/io/inventory/common/exception/CommonExceptionHandler.java
@@ -1,0 +1,28 @@
+package io.inventory.common.exception;
+
+import io.inventory.common.response.ApiResponse;
+import io.inventory.common.response.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class CommonExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ApiResponse<ErrorResponse>> handleCustomException(CustomException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        log.error("[비즈니스 예외 발생] 코드: {}, 설명: {}", errorCode.name(), errorCode.getDescription());
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.error(errorCode));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<ErrorResponse>> handleException(Exception e) {
+        log.error("[서버 예외 발생] 메시지: {}", e.getMessage(), e);
+        return ResponseEntity.status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus())
+                .body(ApiResponse.error(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
+}

--- a/src/main/java/io/inventory/common/exception/CustomException.java
+++ b/src/main/java/io/inventory/common/exception/CustomException.java
@@ -1,0 +1,14 @@
+package io.inventory.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getDescription());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/io/inventory/common/exception/ErrorCode.java
+++ b/src/main/java/io/inventory/common/exception/ErrorCode.java
@@ -1,0 +1,16 @@
+package io.inventory.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum ErrorCode {
+
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String description;
+}

--- a/src/main/java/io/inventory/common/response/ApiResponse.java
+++ b/src/main/java/io/inventory/common/response/ApiResponse.java
@@ -1,0 +1,17 @@
+package io.inventory.common.response;
+
+import io.inventory.common.exception.ErrorCode;
+
+public record ApiResponse<T>(String status, T data) {
+
+    private static final String SUCCESS = "success";
+    private static final String ERROR = "error";
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(SUCCESS, data);
+    }
+
+    public static ApiResponse<ErrorResponse> error(ErrorCode errorCode) {
+        return new ApiResponse<>(ERROR, new ErrorResponse(errorCode));
+    }
+}

--- a/src/main/java/io/inventory/common/response/ErrorResponse.java
+++ b/src/main/java/io/inventory/common/response/ErrorResponse.java
@@ -1,0 +1,9 @@
+package io.inventory.common.response;
+
+import io.inventory.common.exception.ErrorCode;
+
+public record ErrorResponse(String code, String description) {
+    public ErrorResponse(ErrorCode errorCode) {
+        this(errorCode.name(), errorCode.getDescription());
+    }
+}

--- a/src/main/java/io/inventory/warehouse/command/dto/request/WarehouseCreateRequest.java
+++ b/src/main/java/io/inventory/warehouse/command/dto/request/WarehouseCreateRequest.java
@@ -1,0 +1,10 @@
+package io.inventory.warehouse.command.dto.request;
+
+public record WarehouseCreateRequest(
+        String name,
+        Integer postcode,
+        String baseAddress,
+        String detailAddress,
+        String contact
+) {
+}

--- a/src/main/java/io/inventory/warehouse/command/repository/WarehouseRepository.java
+++ b/src/main/java/io/inventory/warehouse/command/repository/WarehouseRepository.java
@@ -1,0 +1,7 @@
+package io.inventory.warehouse.command.repository;
+
+import io.inventory.warehouse.domain.Warehouse;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WarehouseRepository extends JpaRepository<Warehouse, Long> {
+}

--- a/src/main/java/io/inventory/warehouse/command/service/WarehouseCommandService.java
+++ b/src/main/java/io/inventory/warehouse/command/service/WarehouseCommandService.java
@@ -1,0 +1,29 @@
+package io.inventory.warehouse.command.service;
+
+import io.inventory.warehouse.command.dto.request.WarehouseCreateRequest;
+import io.inventory.warehouse.command.repository.WarehouseRepository;
+import io.inventory.warehouse.domain.Warehouse;
+import io.inventory.warehouse.query.dto.WarehouseDetailResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class WarehouseCommandService {
+
+    private final WarehouseRepository warehouseRepository;
+
+    public WarehouseDetailResponse createWarehouse(final WarehouseCreateRequest request) {
+        Warehouse warehouse = warehouseRepository.save(Warehouse.builder()
+                .name(request.name())
+                .postcode(request.postcode())
+                .baseAddress(request.baseAddress())
+                .detailAddress(request.detailAddress())
+                .contact(request.contact())
+                .build());
+
+        return WarehouseDetailResponse.from(warehouse);
+    }
+}

--- a/src/main/java/io/inventory/warehouse/query/dto/WarehouseDetailResponse.java
+++ b/src/main/java/io/inventory/warehouse/query/dto/WarehouseDetailResponse.java
@@ -1,0 +1,28 @@
+package io.inventory.warehouse.query.dto;
+
+import io.inventory.warehouse.domain.Warehouse;
+
+import java.time.LocalDateTime;
+
+public record WarehouseDetailResponse(
+        Long warehouseId,
+        String name,
+        Integer postcode,
+        String baseAddress,
+        String detailAddress,
+        String contact,
+        LocalDateTime createdAt
+) {
+
+    public static WarehouseDetailResponse from(final Warehouse warehouse) {
+        return new WarehouseDetailResponse(
+                warehouse.getWarehouseId(),
+                warehouse.getName(),
+                warehouse.getPostcode(),
+                warehouse.getBaseAddress(),
+                warehouse.getDetailAddress(),
+                warehouse.getContact(),
+                warehouse.getCreatedAt()
+        );
+    }
+}

--- a/src/test/java/io/inventory/warehouse/command/service/WarehouseCommandServiceTest.java
+++ b/src/test/java/io/inventory/warehouse/command/service/WarehouseCommandServiceTest.java
@@ -1,0 +1,46 @@
+package io.inventory.warehouse.command.service;
+
+import io.inventory.warehouse.command.dto.request.WarehouseCreateRequest;
+import io.inventory.warehouse.command.repository.WarehouseRepository;
+import io.inventory.warehouse.query.dto.WarehouseDetailResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@ActiveProfiles("local")
+@Transactional
+@SpringBootTest
+class WarehouseCommandServiceTest {
+
+    @Autowired
+    private WarehouseCommandService warehouseCommandService;
+
+    @Autowired
+    private WarehouseRepository warehouseRepository;
+
+    @Test
+    @DisplayName("창고 생성 시 DB에 저장되고 DTO가 올바르게 반환되어야 한다")
+    void createWarehouse_savesAndReturnsDto() {
+        WarehouseCreateRequest request = new WarehouseCreateRequest(
+                "서울창고",
+                12345,
+                "서울시 강남구",
+                "상세주소 101호",
+                "01012345678"
+        );
+
+        WarehouseDetailResponse response = warehouseCommandService.createWarehouse(request);
+
+        assertThat(response.warehouseId()).isNotNull();
+        assertThat(response.name()).isEqualTo("서울창고");
+        assertThat(response.postcode()).isEqualTo(12345);
+        assertThat(response.baseAddress()).isEqualTo("서울시 강남구");
+        assertThat(response.detailAddress()).isEqualTo("상세주소 101호");
+    }
+
+}


### PR DESCRIPTION
- Warehouse 도메인에 CQRS 패턴을 적용하여 Command/Query 책임을 분리하여 개발하였습니다.
- Command 객체들은 데이터 생성/수정/삭제를 담당합니다. (`WarehouseCommandService`, `WarehouseRepository`)
- Query 객체들은 조회 전용 로직을 담당합니다. (`WarehouseQueryService`, `WarehouseReadRepository`)